### PR TITLE
[fix]tap_count_textviewの初期文字を削除

### DIFF
--- a/app/src/main/res/layout/activity_count_down.xml
+++ b/app/src/main/res/layout/activity_count_down.xml
@@ -81,9 +81,8 @@
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
-        android:text="tapcount"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/timer_textview"/>
+        app:layout_constraintTop_toBottomOf="@+id/timer_textview" />
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
クリック数の部分に表示されていた「tapcount」の文字を消してみました